### PR TITLE
Fix HTML injection vulnerability

### DIFF
--- a/index.html
+++ b/index.html
@@ -221,8 +221,20 @@
          * Updates the display of fixed start and end locations.
          */
         function updateFixedLocationDisplays() {
-            currentStartLocationDiv.innerHTML = `<span class="font-semibold">התחלה:</span> ${startLocation ? startLocation.address : 'לא הוגדר'}`;
-            currentEndLocationDiv.innerHTML = `<span class="font-semibold">סיום:</span> ${endLocation ? endLocation.address : 'לא הוגדר'}`;
+            // Clear existing content
+            currentStartLocationDiv.textContent = '';
+            const startLabel = document.createElement('span');
+            startLabel.className = 'font-semibold';
+            startLabel.textContent = 'התחלה:';
+            currentStartLocationDiv.appendChild(startLabel);
+            currentStartLocationDiv.append(' ', startLocation ? startLocation.address : 'לא הוגדר');
+
+            currentEndLocationDiv.textContent = '';
+            const endLabel = document.createElement('span');
+            endLabel.className = 'font-semibold';
+            endLabel.textContent = 'סיום:';
+            currentEndLocationDiv.appendChild(endLabel);
+            currentEndLocationDiv.append(' ', endLocation ? endLocation.address : 'לא הוגדר');
         }
 
         // Event listener for setting start location


### PR DESCRIPTION
## Summary
- avoid `innerHTML` when displaying start and end locations

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6870eb44d27883209ba3cf1189fbbb80