### PR TITLE
Fix Hebrew text for clearing locations

### DIFF
--- a/index.html
+++ b/index.html
@@ -249,7 +249,7 @@
         clearStartLocationBtn.addEventListener('click', () => {
             startLocation = null;
             updateFixedLocationDisplays(); // Update the text display
-            showMessage('נקודת התחלה נוקתה.', 'info');
+            showMessage('נקודת התחלה נמחקה.', 'info');
             clearRouteDisplay();
         });
 
@@ -277,7 +277,7 @@
         clearEndLocationBtn.addEventListener('click', () => {
             endLocation = null;
             updateFixedLocationDisplays(); // Update the text display
-            showMessage('נקודת סיום נוקתה.', 'info');
+            showMessage('נקודת סיום נמחקה.', 'info');
             clearRouteDisplay();
         });
 


### PR DESCRIPTION
## Summary
- fix misspellings in Hebrew for clearing start and end locations

## Testing
- `grep -n "נמחקה" -n index.html`

------
https://chatgpt.com/codex/tasks/task_e_6870eb4524bc8320b9d18a6c6bbaf908