### PR TITLE
Keep shortened addresses in search fields

### DIFF
--- a/index.html
+++ b/index.html
@@ -229,7 +229,8 @@
             const address = startAddressInput.value.trim();
             if (address) {
                 showMessage('מחפש כתובת לנקודת התחלה...', 'info');
-                const locData = await geocodeAddress(address, detectLanguage(address));
+                const fullAddress = getFullAddress(startAddressInput);
+                const locData = await geocodeAddress(fullAddress, detectLanguage(fullAddress));
                 if (locData) {
                     startLocation = locData;
                     updateFixedLocationDisplays(); // Update the text display
@@ -257,7 +258,8 @@
             const address = endAddressInput.value.trim();
             if (address) {
                 showMessage('מחפש כתובת לנקודת סיום...', 'info');
-                const locData = await geocodeAddress(address, detectLanguage(address));
+                const fullAddress = getFullAddress(endAddressInput);
+                const locData = await geocodeAddress(fullAddress, detectLanguage(fullAddress));
                 if (locData) {
                     endLocation = locData;
                     updateFixedLocationDisplays(); // Update the text display
@@ -285,7 +287,8 @@
             const address = intermediateAddressInput.value.trim();
             if (address) {
                 showMessage('מחפש כתובת למיקום ביניים...', 'info');
-                const locData = await geocodeAddress(address, detectLanguage(address));
+                const fullAddress = getFullAddress(intermediateAddressInput);
+                const locData = await geocodeAddress(fullAddress, detectLanguage(fullAddress));
                 if (locData) {
                     addIntermediateLocation(locData);
                     intermediateAddressInput.value = ''; // Clear input field

--- a/src/geocode.js
+++ b/src/geocode.js
@@ -9,6 +9,8 @@
     root.geocodeAddress = exports.geocodeAddress;
   }
 }(typeof self !== 'undefined' ? self : this, function(){
+  const suggestionData = {};
+
   function detectLanguage(text) {
     return /[\u0590-\u05FF]/.test(text) ? 'he' : 'en';
   }
@@ -57,19 +59,23 @@
     const q = inputElem.value.trim();
     if (q.length < 2) {
       listElem.innerHTML = '';
+      suggestionData[inputElem.id] = [];
       return;
     }
     const lang = detectLanguage(q);
     const suggestions = await fetchAddressSuggestions(q, lang);
+    suggestionData[inputElem.id] = suggestions;
     listElem.innerHTML = suggestions
-      .map(s => `<option value="${s.full}" label="${s.short}"></option>`)
+      .map(s => `<option value="${s.short}"></option>`)
       .join('');
-    if (suggestions.length > 0) {
-      const val = inputElem.value;
-      inputElem.value = '';
-      inputElem.value = val;
-    }
   }
 
-  return { detectLanguage, fetchAddressSuggestions, geocodeAddress, updateSuggestions };
+  function getFullAddress(inputElem) {
+    const val = inputElem.value.trim();
+    const suggs = suggestionData[inputElem.id] || [];
+    const match = suggs.find(s => s.short === val);
+    return match ? match.full : val;
+  }
+
+  return { detectLanguage, fetchAddressSuggestions, geocodeAddress, updateSuggestions, getFullAddress };
 }));


### PR DESCRIPTION
## Summary
- keep a lookup of short to full suggestions
- only show short addresses in `datalist`
- geocode with the full address when setting points

## Testing
- `bash test.sh`
- `npm test` *(fails: jest not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6872105d7800832089201a80bdd57af2