### PR TITLE
Improve suggestion UX and add tests

### DIFF
--- a/src/geocode.js
+++ b/src/geocode.js
@@ -10,6 +10,8 @@
   }
 }(typeof self !== 'undefined' ? self : this, function(){
   const suggestionData = {};
+  const debounceTimers = {};
+  const pendingTokens = {};
 
   function detectLanguage(text) {
     return /[\u0590-\u05FF]/.test(text) ? 'he' : 'en';
@@ -46,7 +48,13 @@
       }
       const data = await response.json();
       if (data && data.length > 0) {
-        return { lat: parseFloat(data[0].lat), lng: parseFloat(data[0].lon), address: data[0].display_name };
+        const full = data[0].display_name;
+        return {
+          lat: parseFloat(data[0].lat),
+          lng: parseFloat(data[0].lon),
+          address: shortenAddress(full),
+          fullAddress: full
+        };
       }
       return null;
     } catch (error) {
@@ -55,19 +63,28 @@
     }
   }
 
-  async function updateSuggestions(inputElem, listElem) {
+  function updateSuggestions(inputElem, listElem) {
+    clearTimeout(debounceTimers[inputElem.id]);
     const q = inputElem.value.trim();
     if (q.length < 2) {
       listElem.innerHTML = '';
       suggestionData[inputElem.id] = [];
       return;
     }
-    const lang = detectLanguage(q);
-    const suggestions = await fetchAddressSuggestions(q, lang);
-    suggestionData[inputElem.id] = suggestions;
-    listElem.innerHTML = suggestions
-      .map(s => `<option value="${s.short}"></option>`)
-      .join('');
+
+    debounceTimers[inputElem.id] = setTimeout(async () => {
+      const lang = detectLanguage(q);
+      const token = Symbol('req');
+      pendingTokens[inputElem.id] = token;
+      const suggestions = await fetchAddressSuggestions(q, lang);
+      if (pendingTokens[inputElem.id] !== token || inputElem.value.trim() !== q) {
+        return;
+      }
+      suggestionData[inputElem.id] = suggestions;
+      listElem.innerHTML = suggestions
+        .map(s => `<option value="${s.short}"></option>`)
+        .join('');
+    }, 300);
   }
 
   function getFullAddress(inputElem) {
@@ -77,5 +94,5 @@
     return match ? match.full : val;
   }
 
-  return { detectLanguage, fetchAddressSuggestions, geocodeAddress, updateSuggestions, getFullAddress };
+  return { detectLanguage, fetchAddressSuggestions, geocodeAddress, updateSuggestions, getFullAddress, shortenAddress };
 }));

--- a/tests/geocode.test.js
+++ b/tests/geocode.test.js
@@ -1,0 +1,18 @@
+const { detectLanguage, shortenAddress } = require('../src/geocode');
+
+describe('detectLanguage', () => {
+  test('detects Hebrew', () => {
+    expect(detectLanguage('שלום')).toBe('he');
+  });
+
+  test('detects English', () => {
+    expect(detectLanguage('hello')).toBe('en');
+  });
+});
+
+describe('shortenAddress', () => {
+  test('returns first three parts', () => {
+    const full = 'Part1, Part2, Part3, Part4, Part5';
+    expect(shortenAddress(full)).toBe('Part1, Part2, Part3');
+  });
+});


### PR DESCRIPTION
## Summary
- shorten addresses returned from geocoder
- debounce and tokenise suggestion fetching to stop dropdown flicker
- expose `shortenAddress` function
- add unit tests for geocode helpers

## Testing
- `npm install`
- `npm test`
- `bash test.sh`


------
https://chatgpt.com/codex/tasks/task_e_6872157b35d88320b592fec5396dc7d2