### PR TITLE
Expose getFullAddress helper to fix address suggestion resolution

### DIFF
--- a/src/geocode.js
+++ b/src/geocode.js
@@ -7,6 +7,7 @@
     root.fetchAddressSuggestions = exports.fetchAddressSuggestions;
     root.updateSuggestions = exports.updateSuggestions;
     root.geocodeAddress = exports.geocodeAddress;
+    root.getFullAddress = exports.getFullAddress;
   }
 }(typeof self !== 'undefined' ? self : this, function(){
   const suggestionData = {};


### PR DESCRIPTION
### Motivation
- The UI failed to resolve addresses selected from the autocomplete/datalist because the `getFullAddress` helper was not available in the browser global scope.
- Using the datalist suggestions and clicking the "הגדר" button resulted in geocoding returning nothing or an error.
- Exposing the helper ensures the full selected display name is passed to the geocoding routine for reliable lookup.

### Description
- Exported `getFullAddress` on the UMD/browser global in `src/geocode.js` via `root.getFullAddress = exports.getFullAddress`.
- This allows page code to call `getFullAddress(inputElem)` and then `geocodeAddress(fullAddress)` to resolve selected suggestions.
- No other functional logic was changed.

### Testing
- Ran `npm install` and it completed successfully.
- Ran `npm test` and Jest passed (2 test suites, 6 tests passed).
- Ran `bash test.sh` and it reported "All checks passed."

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e787738e48320a8f696e22aa60bbc)