### PR TITLE
Improve geocoding error feedback

### DIFF
--- a/index.html
+++ b/index.html
@@ -371,21 +371,33 @@
             currentEndLocationDiv.append(' ', endLocation ? endLocation.address : 'לא הוגדר');
         }
 
+        function buildGeocodeFailureMessage(error) {
+            const baseMessage = error instanceof Error && error.message ? error.message : 'שגיאה בחיפוש הכתובת. נסה שוב.';
+            if (window.location.protocol === 'file:') {
+                return `${baseMessage} אם פתחת את הקובץ מקומית, הפעל שרת מקומי או השתמש בדמו המקוון.`;
+            }
+            return baseMessage;
+        }
+
         // Event listener for setting start location
         setStartLocationBtn.addEventListener('click', async () => {
             const address = startAddressInput.value.trim();
             if (address) {
                 showMessage('מחפש כתובת לנקודת התחלה...', 'info');
-                const fullAddress = getFullAddress(startAddressInput);
-                const locData = await geocodeAddress(fullAddress, detectLanguage(fullAddress));
-                if (locData) {
-                    startLocation = locData;
-                    updateFixedLocationDisplays(); // Update the text display
-                    startAddressInput.value = '';
-                    showMessage('נקודת התחלה הוגדרה!', 'info');
-                    clearRouteDisplay(); // Clear route if locations change
-                } else {
-                    showMessage('לא נמצאה כתובת עבור נקודת ההתחלה.', 'error');
+                try {
+                    const fullAddress = getFullAddress(startAddressInput);
+                    const locData = await geocodeAddress(fullAddress, detectLanguage(fullAddress));
+                    if (locData) {
+                        startLocation = locData;
+                        updateFixedLocationDisplays(); // Update the text display
+                        startAddressInput.value = '';
+                        showMessage('נקודת התחלה הוגדרה!', 'info');
+                        clearRouteDisplay(); // Clear route if locations change
+                    } else {
+                        showMessage('לא נמצאה כתובת עבור נקודת ההתחלה.', 'error');
+                    }
+                } catch (error) {
+                    showMessage(buildGeocodeFailureMessage(error), 'error');
                 }
             } else {
                 showMessage('אנא הזן כתובת לנקודת ההתחלה.', 'error');
@@ -405,16 +417,20 @@
             const address = endAddressInput.value.trim();
             if (address) {
                 showMessage('מחפש כתובת לנקודת סיום...', 'info');
-                const fullAddress = getFullAddress(endAddressInput);
-                const locData = await geocodeAddress(fullAddress, detectLanguage(fullAddress));
-                if (locData) {
-                    endLocation = locData;
-                    updateFixedLocationDisplays(); // Update the text display
-                    endAddressInput.value = '';
-                    showMessage('נקודת סיום הוגדרה!', 'info');
-                    clearRouteDisplay(); // Clear route if locations change
-                } else {
-                    showMessage('לא נמצאה כתובת עבור נקודת הסיום.', 'error');
+                try {
+                    const fullAddress = getFullAddress(endAddressInput);
+                    const locData = await geocodeAddress(fullAddress, detectLanguage(fullAddress));
+                    if (locData) {
+                        endLocation = locData;
+                        updateFixedLocationDisplays(); // Update the text display
+                        endAddressInput.value = '';
+                        showMessage('נקודת סיום הוגדרה!', 'info');
+                        clearRouteDisplay(); // Clear route if locations change
+                    } else {
+                        showMessage('לא נמצאה כתובת עבור נקודת הסיום.', 'error');
+                    }
+                } catch (error) {
+                    showMessage(buildGeocodeFailureMessage(error), 'error');
                 }
             } else {
                 showMessage('אנא הזן כתובת לנקודת הסיום.', 'error');
@@ -434,14 +450,18 @@
             const address = intermediateAddressInput.value.trim();
             if (address) {
                 showMessage('מחפש כתובת למיקום ביניים...', 'info');
-                const fullAddress = getFullAddress(intermediateAddressInput);
-                const locData = await geocodeAddress(fullAddress, detectLanguage(fullAddress));
-                if (locData) {
-                    addIntermediateLocation(locData);
-                    intermediateAddressInput.value = ''; // Clear input field
-                    showMessage('מיקום ביניים נוסף!', 'info');
-                } else {
-                    showMessage('לא נמצאה כתובת עבור החיפוש.', 'error');
+                try {
+                    const fullAddress = getFullAddress(intermediateAddressInput);
+                    const locData = await geocodeAddress(fullAddress, detectLanguage(fullAddress));
+                    if (locData) {
+                        addIntermediateLocation(locData);
+                        intermediateAddressInput.value = ''; // Clear input field
+                        showMessage('מיקום ביניים נוסף!', 'info');
+                    } else {
+                        showMessage('לא נמצאה כתובת עבור החיפוש.', 'error');
+                    }
+                } catch (error) {
+                    showMessage(buildGeocodeFailureMessage(error), 'error');
                 }
             } else {
                 showMessage('אנא הזן כתובת לחיפוש.', 'error');


### PR DESCRIPTION
### Motivation
- Provide clearer, localized error messages when the geocoding service is blocked or rate-limited. 
- Surface network failures instead of silently returning "not found" so users understand why addresses don't resolve. 
- Help users who open `index.html` via `file://` understand CORS/local server limitations. 

### Description
- Add `buildGeocodeServiceMessage` and `buildNetworkMessage` helpers in `src/geocode.js` to produce user-friendly Hebrew error text for 403/429 and network failures. 
- Change `geocodeAddress` to throw descriptive errors for service and network problems instead of returning `null`. 
- Wrap geocoding calls in `index.html` (start, end and intermediate flows) with `try/catch` and show the new messages via `showMessage`, including special guidance when running from `file://`. 

### Testing
- Ran `npm install` which completed successfully. 
- Ran `npm test` and the Jest suite passed: "Test Suites: 2 passed, 2 total" and "Tests: 6 passed, 6 total". 
- Ran `bash test.sh` which reported: "All checks passed."

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e7b569b8083209a7f52b7f0c4a429)