### PR TITLE
Fix address number formatting in suggestions

### DIFF
--- a/src/geocode.js
+++ b/src/geocode.js
@@ -18,8 +18,19 @@
     return /[\u0590-\u05FF]/.test(text) ? 'he' : 'en';
   }
 
+  function normalizeAddressParts(parts) {
+    const cleaned = parts.map(part => part.trim()).filter(Boolean);
+    if (cleaned.length > 1 && /^[0-9]+[A-Za-z\u0590-\u05FF-]*$/.test(cleaned[0])) {
+      const houseNumber = cleaned[0];
+      const streetName = cleaned[1];
+      cleaned.splice(0, 2, `${streetName} ${houseNumber}`);
+    }
+    return cleaned;
+  }
+
   function shortenAddress(displayName) {
-    return displayName.split(',').slice(0, 3).join(',').trim();
+    const parts = normalizeAddressParts(displayName.split(','));
+    return parts.slice(0, 3).join(', ').trim();
   }
 
   function buildGeocodeServiceMessage(status) {


### PR DESCRIPTION
### Motivation
- Users reported that house numbers in some addresses appear separated from the street name in autocomplete and shortened displays.
- The shortened display logic previously split the display name naively on commas which left the house number as a separate leading fragment.

### Description
- Add `normalizeAddressParts` in `src/geocode.js` to trim and clean address parts and merge a leading house number with the following street name when appropriate.
- Update `shortenAddress` to use `normalizeAddressParts` and join parts with consistent punctuation for improved readability.
- Keep behavior of returning up to three parts of the address for the short display.

### Testing
- Ran `npm install` and installation completed without errors.
- Ran `npm test` and the test suites passed (`2` test suites, `6` tests all passed).
- Ran `bash test.sh` and the script reported `All checks passed.`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e7eb1fc2c83209b6d06e67c1074a1)