### PR TITLE
Fix dark mode configuration and saved routes positioning

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,8 @@
     <link rel="manifest" href="manifest.json">
     <!-- Tailwind CSS CDN -->
     <script>
-        tailwind.config = {
+        window.tailwind = window.tailwind || {};
+        window.tailwind.config = {
             darkMode: 'class'
         };
     </script>
@@ -102,6 +103,13 @@
         <span id="themeToggleIcon" aria-hidden="true">🌙</span>
         <span id="themeToggleLabel">מצב כהה</span>
     </button>
+    <div class="fixed top-4 right-4 z-20 flex flex-col items-end gap-1 text-right">
+        <button id="savedRoutesToggleBtn" class="hidden items-center gap-2 bg-white/90 text-slate-700 border border-slate-200 shadow-sm rounded-full px-4 py-2 text-xs sm:text-sm hover:bg-slate-100 dark:bg-slate-800 dark:text-slate-100 dark:border-slate-700 dark:hover:bg-slate-700 transition-colors">
+            📚 מסלולים שמורים
+            <span id="savedRoutesCount" class="inline-flex items-center justify-center min-w-[28px] px-2 py-0.5 text-xs font-semibold rounded-full bg-indigo-100 text-indigo-700 dark:bg-indigo-900/60 dark:text-indigo-100">0</span>
+        </button>
+        <span id="savedRoutesHint" class="text-xs text-slate-400 dark:text-slate-400">אין מסלולים שמורים עדיין.</span>
+    </div>
     <div class="bg-white dark:bg-slate-900 dark:border dark:border-slate-700 p-6 sm:p-8 rounded-2xl shadow-xl w-full max-w-3xl transition-colors">
         <div class="flex flex-col items-center mb-6 text-center">
             <img src="appLogo.png" alt="לוגו האפליקציה" class="w-16 h-16 rounded-full object-cover shadow-sm">
@@ -110,14 +118,6 @@
         </div>
 
         <div id="messageBox" class="mt-4 p-3 rounded-xl hidden" role="status"></div>
-
-        <div class="flex flex-wrap items-center justify-center gap-3 mb-6">
-            <button id="savedRoutesToggleBtn" class="hidden items-center gap-2 bg-white/90 text-slate-700 border border-slate-200 shadow-sm rounded-full px-4 py-2 text-xs sm:text-sm hover:bg-slate-100 dark:bg-slate-800 dark:text-slate-100 dark:border-slate-700 dark:hover:bg-slate-700 transition-colors">
-                📚 מסלולים שמורים
-                <span id="savedRoutesCount" class="inline-flex items-center justify-center min-w-[28px] px-2 py-0.5 text-xs font-semibold rounded-full bg-indigo-100 text-indigo-700 dark:bg-indigo-900/60 dark:text-indigo-100">0</span>
-            </button>
-            <span id="savedRoutesHint" class="text-xs text-slate-400 dark:text-slate-400">אין מסלולים שמורים עדיין.</span>
-        </div>
 
         <div class="space-y-4">
             <section class="step-card rounded-2xl bg-white dark:bg-slate-800" data-step="1" data-active="true" data-complete="false">
@@ -284,7 +284,7 @@
     </div>
     <div id="savedRoutesPanel" class="fixed inset-0 z-40 hidden" aria-hidden="true">
         <div class="absolute inset-0 bg-slate-900/40 backdrop-blur-sm" data-saved-routes-close></div>
-        <div class="absolute right-0 top-0 h-full w-full max-w-md bg-white dark:bg-slate-900 shadow-2xl p-6 flex flex-col gap-4">
+        <div class="absolute left-0 top-0 h-full w-full max-w-md bg-white dark:bg-slate-900 shadow-2xl p-6 flex flex-col gap-4">
             <div class="flex items-center justify-between">
                 <div>
                     <h2 class="text-lg font-semibold text-slate-900 dark:text-slate-100">המסלולים השמורים שלך</h2>


### PR DESCRIPTION
### Motivation
- Tailwind dark mode config could be ignored when `tailwind` was not defined, causing the theme toggle to behave inconsistently.
- The saved-routes quick access control was duplicated and not easily reachable in the RTL layout.
- The saved routes side panel was anchored to the right which is not ideal for an RTL interface and visual flow.

### Description
- Initialize the Tailwind config on `window.tailwind` (`window.tailwind.config = { darkMode: 'class' }`) to ensure the dark mode setting is applied reliably.
- Move the saved routes quick-access control into a fixed top-right container and remove the previous inline duplicate.
- Reposition the saved routes panel to the left side (`left-0`) so it aligns better with the RTL layout.
- Adjust minor markup positioning to keep the main header layout clean after moving the saved-routes control.

### Testing
- Ran `npm install` which completed successfully and reported the project is up to date with no vulnerabilities found.
- Ran `npm test` which executed Jest and reported `Test Suites: 2 passed, 2 total` and `Tests: 6 passed, 6 total`.
- Ran `bash test.sh` which returned `All checks passed.`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e8ba871808320aa6bd354fbfbbd85)