### PR TITLE
Fix saved routes panel script placement

### DIFF
--- a/index.html
+++ b/index.html
@@ -949,31 +949,6 @@
 
         openInGoogleMapsBtn.addEventListener('click', openInGoogleMaps);
 
-        savedRoutesToggleBtn.addEventListener('click', openSavedRoutesPanel);
-        openSavedRoutesPanelBtn.addEventListener('click', openSavedRoutesPanel);
-        closeSavedRoutesPanelBtn.addEventListener('click', closeSavedRoutesPanel);
-        savedRoutesPanel.addEventListener('click', (event) => {
-            if (event.target.matches('[data-saved-routes-close]')) {
-                closeSavedRoutesPanel();
-            }
-        });
-
-        if ('serviceWorker' in navigator) {
-            window.addEventListener('load', () => {
-                navigator.serviceWorker.register('./service-worker.js').catch((error) => {
-                    console.warn('Service worker registration failed:', error);
-                });
-            });
-        }
-
-        updateIntermediateLocationsList();
-        updateFixedLocationDisplays();
-        updateSavedRoutesList();
-        clearRouteDisplay();
-        setActiveStep(1);
-    </script>
-</body>
-</html>
         function openSavedRoutesPanel() {
             savedRoutesPanel.classList.remove('hidden');
             savedRoutesPanel.setAttribute('aria-hidden', 'false');
@@ -1003,3 +978,29 @@
                 </div>
             `;
         }
+
+        savedRoutesToggleBtn.addEventListener('click', openSavedRoutesPanel);
+        openSavedRoutesPanelBtn.addEventListener('click', openSavedRoutesPanel);
+        closeSavedRoutesPanelBtn.addEventListener('click', closeSavedRoutesPanel);
+        savedRoutesPanel.addEventListener('click', (event) => {
+            if (event.target.matches('[data-saved-routes-close]')) {
+                closeSavedRoutesPanel();
+            }
+        });
+
+        if ('serviceWorker' in navigator) {
+            window.addEventListener('load', () => {
+                navigator.serviceWorker.register('./service-worker.js').catch((error) => {
+                    console.warn('Service worker registration failed:', error);
+                });
+            });
+        }
+
+        updateIntermediateLocationsList();
+        updateFixedLocationDisplays();
+        updateSavedRoutesList();
+        clearRouteDisplay();
+        setActiveStep(1);
+    </script>
+</body>
+</html>


### PR DESCRIPTION
### Motivation
- The saved-routes panel helpers were declared after the event listener bindings which could cause runtime errors when the UI tried to call them. 
- Define `openSavedRoutesPanel`, `closeSavedRoutesPanel`, and `renderRoutePreview` before they are used so event handlers have valid references. 
- Prevent broken behavior when opening, closing or previewing saved routes in the UI.

### Description
- Moved the `openSavedRoutesPanel`, `closeSavedRoutesPanel`, and `renderRoutePreview` helper functions earlier in the main script inside `index.html` so they exist before bindings. 
- Reordered the registration of event listeners for `savedRoutesToggleBtn`, `openSavedRoutesPanelBtn`, `closeSavedRoutesPanelBtn`, and `savedRoutesPanel` to occur after the helpers are defined. 
- Did not modify helper logic; this change is a placement/ordering fix to avoid undefined-function errors. 
- A UI screenshot was captured while validating the fix (non-code artifact).

### Testing
- Ran `npm install` and dependencies installed successfully with no vulnerabilities reported. 
- Ran `npm test` and unit tests passed with `2` test suites and `6` tests (`Test Suites: 2 passed, 2 total; Tests: 6 passed, 6 total`). 
- Ran `bash test.sh` and it reported `All checks passed.`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e8dc468848320a1cb664384be06ab)